### PR TITLE
Add types to new generate arguments

### DIFF
--- a/sbws/core/generate.py
+++ b/sbws/core/generate.py
@@ -49,14 +49,14 @@ def gen_parser(sub):
                    type=int,
                    help="Number of most significant digits to round bw "
                         "when scaling as Torflow. (Default: 3)")
-    p.add_argument('-p', '--secs-recent', default=None,
+    p.add_argument('-p', '--secs-recent', default=None, type=float,
                    help="How many secs in the past are results being "
                         "still considered. Note this value will supersede "
                         "data_period in the configuration. (Default: None)")
-    p.add_argument('-a', '--secs-away', default=DAY_SECS,
+    p.add_argument('-a', '--secs-away', default=DAY_SECS, type=float,
                    help="How many secs results have to be away from each "
                         "other. (Default: 86400 - one day -)")
-    p.add_argument('-n', '--min-num', default=NUM_MIN_RESULTS,
+    p.add_argument('-n', '--min-num', default=NUM_MIN_RESULTS, type=int,
                    help="Mininum number of a results to consider them."
                         "(Default: 2)")
 


### PR DESCRIPTION
--secs-recent is a float to support weird people who might want to
include fractional seconds
--secs-away is a float for the same reason
--min-num is an int because there's no such thing as half a result