### PR TITLE
Include headers about progress in all the bw files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Change default directories when sbws is run from a system service (#28268).
+- Include the headers about eligible relays in all the bandwidth files,
+  not only in the ones that does not have enough eligible relays (#28365).
 
 ## [1.0.0] - 2018-10-29
 

--- a/sbws/lib/v3bwfile.py
+++ b/sbws/lib/v3bwfile.py
@@ -896,10 +896,9 @@ class V3BWFile(object):
         if number_consensus_relays is not None:
             statsd, success = self.measured_progress_stats(
                 bw_lines, number_consensus_relays, min_perc_reached_before)
-            # add statistics about progress only when there are not enough
-            # measured relays. Should some stats be added always?
+            # add statistics about progress always
+            header.add_stats(**statsd)
             if not success:
-                header.add_stats(**statsd)
                 bw_lines = []
                 state['min_perc_reached'] = None
             else:

--- a/tests/unit/lib/test_v3bwfile.py
+++ b/tests/unit/lib/test_v3bwfile.py
@@ -4,7 +4,8 @@ import json
 import os.path
 
 from sbws import __version__ as version
-from sbws.globals import SPEC_VERSION, SBWS_SCALING, TORFLOW_SCALING
+from sbws.globals import (SPEC_VERSION, SBWS_SCALING, TORFLOW_SCALING,
+                          MIN_REPORT)
 from sbws.lib.resultdump import Result, load_result_file, ResultSuccess
 from sbws.lib.v3bwfile import (V3BWHeader, V3BWLine, TERMINATOR, LINE_SEP,
                                KEYVALUE_SEP_V110, num_results_of_type,
@@ -234,9 +235,15 @@ def test_update_progress(datadir, tmpdir):
                            state)
     assert header.percent_eligible_relays == '50'
     assert state.get('min_perc_reached') is None
+    # Test that the headers are also included when there are enough eligible
+    # relays
     number_consensus_relays = 3
     header = V3BWHeader(str(now_unixts()))
     bwfile.update_progress(bw_lines_raw, header, number_consensus_relays,
                            state)
     assert state.get('min_perc_reached') == now_isodt_str()
-    assert not hasattr(header, 'percent_eligible_relays')
+    assert header.minimum_number_eligible_relays == '2'
+    assert header.minimum_percent_eligible_relays == str(MIN_REPORT)
+    assert header.number_consensus_relays == '3'
+    assert header.number_eligible_relays == '3'
+    assert header.percent_eligible_relays == '100'


### PR DESCRIPTION
Include the headers about eligible relays in all the bandwidth
files, not only in the ones that does not have enough eligible
relays (#28365).