### PR TITLE
Travis: use the high-availability keyserver pool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script: tox
 
 before_install:
     - gpg --version
-    - gpg --keyserver hkp://pool.sks-keyservers.net --recv A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89
+    - gpg --keyserver hkp://ha.pool.sks-keyservers.net --recv A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89
     - gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | sudo apt-key add
     - echo "deb https://deb.torproject.org/torproject.org trusty main" | sudo tee -a /etc/apt/sources.list
     - echo "deb-src https://deb.torproject.org/torproject.org trusty main" | sudo tee -a /etc/apt/sources.list


### PR DESCRIPTION
sbws is getting a significant number of build failures due to keyserver failures.

Using the high-availability keyserver pool reduces the probability of failure.