### PR TITLE
v3bwfile: stop using torflow_round_digs

### DIFF
--- a/sbws/core/generate.py
+++ b/sbws/core/generate.py
@@ -2,7 +2,7 @@ from math import ceil
 
 from sbws.globals import (fail_hard, SBWS_SCALE_CONSTANT, TORFLOW_SCALING,
                           SBWS_SCALING, TORFLOW_BW_MARGIN, PROP276_ROUND_DIG,
-                          DAY_SECS, NUM_MIN_RESULTS, TORFLOW_ROUND_DIG)
+                          DAY_SECS, NUM_MIN_RESULTS)
 from sbws.lib.v3bwfile import V3BWFile
 from sbws.lib.resultdump import load_recent_results_in_datadir
 from argparse import ArgumentDefaultsHelpFormatter
@@ -54,13 +54,8 @@ def gen_parser(sub):
     p.add_argument('-m', '--torflow-bw-margin', default=TORFLOW_BW_MARGIN,
                    type=float,
                    help="Cap maximum bw when scaling as Torflow. ")
-    p.add_argument('-r', '--torflow-round-digs', default=TORFLOW_ROUND_DIG,
-                   type=int,
-                   help="Number of most significant digits to round "
-                        "bw in Torflow. This option is kept for compatibility "
-                        "with 1.0.x versions but it's silently ignored."
-                        "Use --round-digs instead.")
-    p.add_argument('-d', '--round-digs', default=PROP276_ROUND_DIG, type=int,
+    p.add_argument('-r', '--round-digs', '--torflow-round-digs',
+                   default=PROP276_ROUND_DIG, type=int,
                    help="Number of most significant digits to round bw.")
     p.add_argument('-p', '--secs-recent', default=None, type=int,
                    help="How many secs in the past are results being "

--- a/sbws/core/generate.py
+++ b/sbws/core/generate.py
@@ -2,7 +2,7 @@ from math import ceil
 
 from sbws.globals import (fail_hard, SBWS_SCALE_CONSTANT, TORFLOW_SCALING,
                           SBWS_SCALING, TORFLOW_BW_MARGIN, PROP276_ROUND_DIG,
-                          DAY_SECS, NUM_MIN_RESULTS)
+                          DAY_SECS, NUM_MIN_RESULTS, TORFLOW_ROUND_DIG)
 from sbws.lib.v3bwfile import V3BWFile
 from sbws.lib.resultdump import load_recent_results_in_datadir
 from argparse import ArgumentDefaultsHelpFormatter
@@ -54,8 +54,13 @@ def gen_parser(sub):
     p.add_argument('-m', '--torflow-bw-margin', default=TORFLOW_BW_MARGIN,
                    type=float,
                    help="Cap maximum bw when scaling as Torflow. ")
-    p.add_argument('-r', '--round-digs', '--torflow-round-digs',
-                   default=PROP276_ROUND_DIG, type=int,
+    p.add_argument('-r', '--torflow-round-digs', default=TORFLOW_ROUND_DIG,
+                   type=int,
+                   help="Number of most significant digits to round "
+                        "bw in Torflow. This option is kept for compatibility "
+                        "with 1.0.x versions but it's silently ignored."
+                        "Use --round-digs instead.")
+    p.add_argument('-d', '--round-digs', default=PROP276_ROUND_DIG, type=int,
                    help="Number of most significant digits to round bw.")
     p.add_argument('-p', '--secs-recent', default=None, type=int,
                    help="How many secs in the past are results being "
@@ -106,7 +111,7 @@ def main(args, conf):
     bw_file = V3BWFile.from_results(results, state_fpath, args.scale_constant,
                                     scaling_method,
                                     torflow_cap=args.torflow_bw_margin,
-                                    torflow_round_digs=args.torflow_round_digs,
+                                    round_digs=args.round_digs,
                                     secs_recent=args.secs_recent,
                                     secs_away=args.secs_away,
                                     min_num=args.min_num,

--- a/sbws/core/generate.py
+++ b/sbws/core/generate.py
@@ -66,6 +66,7 @@ def gen_parser(sub):
                         "other.")
     p.add_argument('-n', '--min-num', default=NUM_MIN_RESULTS, type=int,
                    help="Mininum number of a results to consider them.")
+    return p
 
 
 def main(args, conf):

--- a/sbws/lib/v3bwfile.py
+++ b/sbws/lib/v3bwfile.py
@@ -488,7 +488,7 @@ class V3BWFile(object):
                      scaling_method=TORFLOW_SCALING,
                      torflow_obs=TORFLOW_OBS_LAST,
                      torflow_cap=TORFLOW_BW_MARGIN,
-                     torflow_round_digs=PROP276_ROUND_DIG,
+                     round_digs=PROP276_ROUND_DIG,
                      secs_recent=None, secs_away=None, min_num=0,
                      consensus_path=None, max_bw_diff_perc=MAX_BW_DIFF_PERC,
                      reverse=False):
@@ -533,7 +533,7 @@ class V3BWFile(object):
             # log.debug(bw_lines[-1])
         elif scaling_method == TORFLOW_SCALING:
             bw_lines = cls.bw_torflow_scale(bw_lines_raw, torflow_obs,
-                                            torflow_cap, torflow_round_digs)
+                                            torflow_cap, round_digs)
             # log.debug(bw_lines[-1])
             cls.update_progress(
                 cls, bw_lines, header, number_consensus_relays, state)

--- a/tests/unit/core/test_generate.py
+++ b/tests/unit/core/test_generate.py
@@ -1,0 +1,34 @@
+"""Unit tests for sbws.core.generate module."""
+import argparse
+
+from sbws.globals import TORFLOW_ROUND_DIG, PROP276_ROUND_DIG
+from sbws.core.generate import gen_parser
+
+
+def test_gen_parser_arg_round_digs():
+    """
+    Test that both --torflow-round-digs and --round-digs arguments can be
+    passed and round-digs is PROP276_ROUND_DIG by default.
+
+    """
+    parent_parser = argparse.ArgumentParser(prog='sbws')
+    subparsers = parent_parser.add_subparsers(help='generate help')
+    parser_generate = gen_parser(subparsers)
+    # Explicitely set empty arguments, otherwise pytest will use pytest
+    # arguments
+    args = parser_generate.parse_args([])
+    assert args.round_digs == PROP276_ROUND_DIG
+    # torflow_round_digs is not in the Namespace
+    assert getattr(args, 'torflow_round_digs', None) is None
+    # but it can still be passed as an argument
+    args = parser_generate.parse_args(['--torflow-round-digs',
+                                       str(TORFLOW_ROUND_DIG)])
+    # though the variable is named round_digs
+    assert args.round_digs == TORFLOW_ROUND_DIG
+    # or use the short version
+    args = parser_generate.parse_args(['-r', str(TORFLOW_ROUND_DIG)])
+    assert args.round_digs == TORFLOW_ROUND_DIG
+    # or use round-digs explicitely
+    args = parser_generate.parse_args(['--round-digs',
+                                       str(PROP276_ROUND_DIG)])
+    assert args.round_digs == PROP276_ROUND_DIG

--- a/tests/unit/lib/test_v3bwfile.py
+++ b/tests/unit/lib/test_v3bwfile.py
@@ -6,7 +6,7 @@ import os.path
 
 from sbws import __version__ as version
 from sbws.globals import (SPEC_VERSION, SBWS_SCALING, TORFLOW_SCALING,
-                          MIN_REPORT)
+                          MIN_REPORT, TORFLOW_ROUND_DIG, PROP276_ROUND_DIG)
 from sbws.lib.resultdump import Result, load_result_file, ResultSuccess
 from sbws.lib.v3bwfile import (V3BWHeader, V3BWLine, TERMINATOR, LINE_SEP,
                                KEYVALUE_SEP_V1, num_results_of_type,
@@ -266,14 +266,21 @@ def test_sbws_scale(datadir):
 
 def test_torflow_scale(datadir):
     results = load_result_file(str(datadir.join("results.txt")))
-    v3bwfile = V3BWFile.from_results(results, scaling_method=TORFLOW_SCALING)
-    assert v3bwfile.bw_lines[0].bw == 520
     v3bwfile = V3BWFile.from_results(results, scaling_method=TORFLOW_SCALING,
-                                     torflow_cap=0.0001)
-    assert v3bwfile.bw_lines[0].bw == 520
+                                     round_digs=TORFLOW_ROUND_DIG)
+    assert v3bwfile.bw_lines[0].bw == 524
     v3bwfile = V3BWFile.from_results(results, scaling_method=TORFLOW_SCALING,
-                                     torflow_cap=1, round_digs=1)
-    assert v3bwfile.bw_lines[0].bw == 500
+                                     torflow_cap=0.0001,
+                                     round_digs=TORFLOW_ROUND_DIG)
+    assert v3bwfile.bw_lines[0].bw == 524
+    v3bwfile = V3BWFile.from_results(results, scaling_method=TORFLOW_SCALING,
+                                     torflow_cap=1,
+                                     round_digs=TORFLOW_ROUND_DIG)
+    assert v3bwfile.bw_lines[0].bw == 524
+    v3bwfile = V3BWFile.from_results(results, scaling_method=TORFLOW_SCALING,
+                                     torflow_cap=1,
+                                     round_digs=PROP276_ROUND_DIG)
+    assert v3bwfile.bw_lines[0].bw == 520
 
 
 def test_results_away_each_other(datadir):

--- a/tests/unit/lib/test_v3bwfile.py
+++ b/tests/unit/lib/test_v3bwfile.py
@@ -272,7 +272,7 @@ def test_torflow_scale(datadir):
                                      torflow_cap=0.0001)
     assert v3bwfile.bw_lines[0].bw == 520
     v3bwfile = V3BWFile.from_results(results, scaling_method=TORFLOW_SCALING,
-                                     torflow_cap=1, torflow_round_digs=1)
+                                     torflow_cap=1, round_digs=1)
     assert v3bwfile.bw_lines[0].bw == 500
 
 


### PR DESCRIPTION
The generate cli argument changed name to round_digs but the
argument passed to V3BWFile.from_results was using the old
torflow_round_digs.

Closes bug #28602. Bugfix 1.0.3-dev0.