### PR TITLE
docs: replace http by https in links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -82,8 +82,11 @@ are 10MB and it will keep 50 rotated log files.
 .. _virtualenv: https://virtualenv.pypa.io/en/stable/installation/
 .. _Stem: https://stem.torproject.org/
 .. _socks: http://docs.python-requests.org/en/master/user/advanced/#socks
+.. https://readthedocs.org/projects/requests/ redirect to this, but the
+.. certificate of this signed by rtd
 .. _Requests: http://docs.python-requests.org/
-.. _Flake8: http://flake8.pycqa.org/
+.. http://flake8.pycqa.org/ certificate is signed by rtf
+.. _Flake8: https://flake8.readthedocs.org/
 .. _pytest: https://docs.pytest.org/
 .. _tox: https://tox.readthedocs.io
 .. _Coverage: https://coverage.readthedocs.io/

--- a/docs/source/documenting.rst
+++ b/docs/source/documenting.rst
@@ -41,7 +41,7 @@ They are included in most distributions. In Debian install them running::
     apt install texlive-latex-extra
 
 
-.. _Sphinx: http://www.sphinx-doc.org
+.. _Sphinx: https://www.sphinx-doc.org
 .. _recommonmark: https://recommonmark.readthedocs.io/
 .. _Pylint: https://www.pylint.org/
-.. _Tex: http://www.tug.org/texlive/acquire.html
+.. _Tex: https://www.tug.org/texlive/acquire.html

--- a/docs/source/specification.rst
+++ b/docs/source/specification.rst
@@ -201,7 +201,8 @@ scaling method.
 
 .. _torflow: https://gitweb.torproject.org/torflow.git
 .. _stem: https://stem.torproject.org
-.. _requests: https://docs.python-requests.org/
+.. https://github.com/requests/requests/issues/4885
+.. _requests: http://docs.python-requests.org/
 .. _peerflow: https://www.nrl.navy.mil/itd/chacs/sites/www.nrl.navy.mil.itd.chacs/files/pdfs/16-1231-4353.pdf
 .. _torflow_scaling: https://gitweb.torproject.org/torflow.git/tree/NetworkScanners/BwAuthority/README.spec.txt#n298
 .. _bandwidth_file_spec: https://gitweb.torproject.org/torspec.git/tree/bandwidth-file-spec.txt

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -18,7 +18,7 @@ To run the tests::
 
     tox
 
-.. _Flake8: http://flake8.pycqa.org/
+.. _Flake8: https://flake8.readthedocs.io/
 .. _pytest: https://docs.pytest.org/
 .. _tox: https://tox.readthedocs.io
 .. _Coverage: https://coverage.readthedocs.io/


### PR DESCRIPTION
or change domain to the certificate's CN or leave http when the
certificate's CN doesn't match the domain.

Closes #28661.