### PR TITLE
CI: check broken links in the docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,12 @@ python:
   - "3.5"
   - "3.6"
 install: pip install tox-travis
-script: tox
+script:
+  - tox
+  # This is not in included in the tox envlist, in order to don't need Internet
+  # when running tox
+  - tox -e doclinks
+  - tox -e clean
 
 before_install:
     - gpg --version

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 skip_missing_interpreters = True
-envlist = py35, py36, inst, setup, unit, integration, lint, stats, doc, clean
+envlist = py35, py36, inst, setup, unit, integration, lint, stats, doc
 
 [travis]
 python =
-    3.5: py35, inst, setup, unit, integration, lint, doc
+    3.5: py35, inst, setup, unit, integration, lint, doc, doclinks
     3.6: py36, inst, setup, unit, integration
 
 [testenv]
@@ -82,6 +82,12 @@ commands =
     make html
     # this requires build the pdf images
     # make latexpdf
-    # this requires network
-    # make linkcheck
     make man
+
+# this requires Internet, it should not be in envlist
+[testenv:doclinks]
+deps = .[doc]
+whitelist_externals = make
+changedir = docs
+commands =
+    make linkcheck


### PR DESCRIPTION
Add a tox environment to check the links and call it from travis.
It's not run by tox in order to do not need Internet running tox.
The environment clean is also call from travis, in order to have
sphinx installed when checking the links.

Closes #28670.