### PR TITLE
docs: add scanner and destination requirements

### DIFF
--- a/DEPLOY.rst
+++ b/DEPLOY.rst
@@ -19,8 +19,16 @@ destination requirements
 - A Web server installed and running that supports HTTP GET, HEAD and
   Range (:rfc:`7233`) requests.
   ``Apache`` HTTP Server and ``Nginx`` support them.
-- Optional support for TLS
+- TLS support to avoid HTTP content caches at the various exit nodes.
+- Certificates can be self-signed.
 - A large file; at the time of writing, at least 1 GiB in size
+  It can be created running::
+
+      head -c $((1024*1024*1024)) /dev/urandom > 1GiB
+
+- A fixed IP address or a domain name.
+- Bandwidth: at least 12.5MB/s (100 Mbit/s).
+- Network traffic: around 12-15GB/day.
 
 scanner setup
 ----------------------

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -58,7 +58,7 @@ to configure, deploy and run ``sbws``.
 System physical requirements
 -----------------------------
 
-- Bandwidth: at least 20MB/s (160 Mbit/s). The more the better.
+- Bandwidth: at least 12.5MB/s (100 Mbit/s).
 - Free RAM: at least 1.5GB
 - Free disk: at least 3GB
 


### PR DESCRIPTION
based on Torflow's documentation.

Closes bug #28647. Bugfix v0.4.0