### PR TITLE
config: stop allowing http servers without tls

### DIFF
--- a/sbws/lib/destination.py
+++ b/sbws/lib/destination.py
@@ -98,9 +98,6 @@ class Destination:
     def __init__(self, url, max_dl, verify):
         self._max_dl = max_dl
         u = urlparse(url)
-        # these things should have been verified in verify_config
-        assert u.scheme in ['http', 'https']
-        assert u.netloc
         self._url = u
         self._verify = verify
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -72,6 +72,9 @@ def conf(sbwshome_dir):
     conf['tor']['run_dpath'] = os.path.join(sbwshome_dir, 'tor', 'run')
     conf['destinations']['foo'] = 'on'
     conf['destinations.foo'] = {}
+    # The test server is not using TLS. Ideally it should also support TLS
+    # If the url would start with https but the request is not using TLS,
+    # the request would hang.
     conf['destinations.foo']['url'] = 'http://127.0.0.1:28888/sbws.bin'
     conf['tor']['extra_lines'] = """  # noqa: E501
 DirAuthority auth1 orport=2002 no-v2 v3ident=D7DBC517EFD2BA1A5012CF1BD0BB38F17C8160BD 127.10.0.1:2003 AA45C13025C037F056E734169891878ED0880231

--- a/tests/unit/util/test_config.py
+++ b/tests/unit/util/test_config.py
@@ -190,14 +190,17 @@ def test_validate_bool():
 
 def test_validate_url():
     goods = [
-        'http://example.com', 'http://example.com/',
-        'http://example.com/foo.bar',
-        'http://example.com/foo/bar',
-        'http://user@example.com',
+        'https://example.com', 'https://example.com/',
+        'https://example.com/foo.bar',
+        'https://example.com/foo/bar',
+        'https://user@example.com',
+        'https://48.290.983.123:4443',
+        'http://127.0.0.1:8000'
     ]
     bads = [
         'ftp://example.com/foo.bar',
         'http://', 'http:///',
+        'http://example.com',
     ]
     for val in goods:
         d = {'': val}


### PR DESCRIPTION
Destinations' Web servers must support TLS to avoid contents cache.

Fixes bug #28789. Bugfix v0.2.0.