### PR TITLE
relaylist: remove assertions that fail measurement

### DIFF
--- a/sbws/lib/relaylist.py
+++ b/sbws/lib/relaylist.py
@@ -42,14 +42,12 @@ class Relay:
     def _from_desc(self, attr):
         if not self._desc:
             return None
-        assert hasattr(self._desc, attr)
-        return getattr(self._desc, attr)
+        return getattr(self._desc, attr, None)
 
     def _from_ns(self, attr):
         if not self._ns:
             return None
-        assert hasattr(self._ns, attr)
-        return getattr(self._ns, attr)
+        return getattr(self._ns, attr, None)
 
     @property
     def nickname(self):


### PR DESCRIPTION
When the descriptor or network status of a relay was not obtained,
some attributes can't be obtained it can be return None instead
of failing the measurement.
Also, there's no need for hasattr when getattr can just return
None as default.

Closes #28870. Bugfix v0.4.0