### PR TITLE
generate: Load all results, including error ones

### DIFF
--- a/sbws/core/generate.py
+++ b/sbws/core/generate.py
@@ -94,7 +94,7 @@ def main(args, conf):
     reset_bw_ipv4_changes = conf.getboolean('general', 'reset_bw_ipv4_changes')
     reset_bw_ipv6_changes = conf.getboolean('general', 'reset_bw_ipv6_changes')
     results = load_recent_results_in_datadir(
-        fresh_days, datadir, success_only=True,
+        fresh_days, datadir,
         on_changed_ipv4=reset_bw_ipv4_changes,
         on_changed_ipv6=reset_bw_ipv6_changes)
     if len(results) < 1:


### PR DESCRIPTION
The bandwidth file is generated only with relays that have some
successful measurements, but we forgot to load all results
(including the relays with failed measurements) after we started
to include the number of failure measurements in each relay
bandwidth line.

Closes #29568. Bugfix v0.4.0 (line introduced in v0.1.0).