### PR TITLE
fix: relaylist: Convert consensus bandwidth to bytes

### DIFF
--- a/sbws/lib/relaylist.py
+++ b/sbws/lib/relaylist.py
@@ -120,7 +120,12 @@ class Relay:
 
     @property
     def consensus_bandwidth(self):
-        return self._from_ns('bandwidth')
+        """Return the consensus bandwidth in Bytes.
+
+        Consensus bandwidth is the only bandwidth value that is in kilobytes.
+        """
+        if self._from_ns('bandwidth') is not None:
+            return self._from_ns('bandwidth') * 1000
 
     @property
     def consensus_bandwidth_is_unmeasured(self):


### PR DESCRIPTION
Since all the other bandwidth values are in bytes and sbws should
work with bytes until it generates the final `bw`.

Closes: #29707. Bugfix v1.0.3.