### PR TITLE
fix: globals: Fetch descriptors early

### DIFF
--- a/sbws/globals.py
+++ b/sbws/globals.py
@@ -36,6 +36,28 @@ TORRC_STARTING_POINT = {
     'SafeLogging': '0',
     'LogTimeGranularity': '1',
     'ProtocolWarnings': '1',
+    # Text and options from
+    # https://stem.torproject.org/tutorials/mirror_mirror_on_the_wall.html#can-i-get-descriptors-from-the-tor-process
+    #
+    # Descriptors have a range of time during which they're valid. To get the
+    # most recent descriptor information, regardless of if Tor needs it or not,
+    # set the following.
+    'FetchDirInfoEarly':  '1',
+    'FetchDirInfoExtraEarly': '1',
+
+    # Tor doesn't need all descriptors to function. In particular...
+    #
+    #   * Tor no longer downloads server descriptors by default, opting
+    #     for microdescriptors instead.
+    #
+    #   * If you aren't actively using Tor as a client then Tor will
+    #     eventually stop downloading descriptor information altogether
+    #     to relieve load on the network.
+    #
+    # To download descriptors regardless of if they're needed by the
+    # Tor process or not set...
+
+    'FetchUselessDescriptors': '1'
 }
 # Options that need to be set at runtime.
 TORRC_RUNTIME_OPTIONS = {

--- a/sbws/globals.py
+++ b/sbws/globals.py
@@ -49,8 +49,7 @@ TORRC_STARTING_POINT = {
     #     eventually stop downloading descriptor information altogether
     #     to relieve load on the network.
     #
-    # To download descriptors regardless of if they're needed by the
-    # Tor process or not set...
+    # To make Tor keep fetching descriptors, even when idle.
 
     'FetchUselessDescriptors': '1'
 }

--- a/sbws/globals.py
+++ b/sbws/globals.py
@@ -45,11 +45,6 @@ TORRC_STARTING_POINT = {
     'FetchDirInfoEarly':  '1',
     'FetchDirInfoExtraEarly': '1',
 
-    # Tor doesn't need all descriptors to function. In particular...
-    #
-    #   * Tor no longer downloads server descriptors by default, opting
-    #     for microdescriptors instead.
-    #
     #   * If you aren't actively using Tor as a client then Tor will
     #     eventually stop downloading descriptor information altogether
     #     to relieve load on the network.

--- a/sbws/lib/relaylist.py
+++ b/sbws/lib/relaylist.py
@@ -440,7 +440,7 @@ class RelayList:
                 # Update the consensus and descriptor data.
                 r.set_router_status(new_relays_dict[r.fingerprint])
                 try:
-                    descriptor = c.get_server_descriptor(r.pringerprint,
+                    descriptor = c.get_server_descriptor(r.fingerprint,
                                                          default=None)
                     if not descriptor:
                         log.warning("Could not get a descriptor for %s (%s)",

--- a/sbws/lib/relaylist.py
+++ b/sbws/lib/relaylist.py
@@ -298,6 +298,7 @@ class Relay:
         """
         self._ns = router_status
 
+
 class RelayList:
     ''' Keeps a list of all relays in the current Tor network and updates it
     transparently in the background. Provides useful interfaces for getting


### PR DESCRIPTION
So that sbws detect early changes in the relay descriptors.

Closes: #30733. Bugfix v0.2.0.